### PR TITLE
Add flat-top layout & map generation

### DIFF
--- a/src/Hexagons/Layout.elm
+++ b/src/Hexagons/Layout.elm
@@ -1,6 +1,7 @@
 module Hexagons.Layout exposing
     ( Point, Orientation, Layout
     , orientationLayoutPointy
+    , orientationLayoutFlat
     , hexToPoint, pointToHex
     , hexToOffset, offsetToHex
     , polygonCorners
@@ -17,9 +18,9 @@ See <http://www.redblobgames.com/grids/hexagons/implementation.html> for referen
 @docs Point, Orientation, Layout
 
 
-# Contants
+# Constants
 
-@docs orientationLayoutPointy
+@docs orientationLayoutPointy, orientationLayoutFlat
 
 
 # Hex to point and point to hex conversions
@@ -99,7 +100,7 @@ precision division number =
     (toFloat << round) (number * k) / k
 
 
-{-| Contant definition of pointy hexagon orientation
+{-| Constant definition of pointy hexagon orientation
 -}
 orientationLayoutPointy : Orientation
 orientationLayoutPointy =
@@ -118,6 +119,23 @@ orientationLayoutPointy =
     , start_angle = 0.5
     }
 
+{-| Constant definition for flat-top hexagon orientation -}
+orientationLayoutFlat : Orientation
+orientationLayoutFlat =
+    { forward_matrix =
+        { f0 = 3.0 / 2.0
+        , f1 = 0.0
+        , f2 = sqrt 3.0 / 2
+        , f3 = sqrt 3
+        }
+    , inverse_matrix =
+        { f0 = 2.0 / 3.0
+        , f1 = 0.0
+        , f2 = -1.0 / 3.0
+        , f3 = 1.0 / sqrt 3
+        }
+    , start_angle = 0
+    }
 
 {-| Turn Hex coordinates into a Point location on a Layout
 -}

--- a/src/Hexagons/Map.elm
+++ b/src/Hexagons/Map.elm
@@ -3,6 +3,7 @@ module Hexagons.Map exposing
     , hashHex
     , getHex
     , rectangularPointyTopMap
+    , rectangularFlatTopMap
     )
 
 {-| This module solves the problem of generating and storing the Map data. We are using Elm dictionary as the Map storage engine with Hex coordinate tuple as the key.
@@ -100,6 +101,41 @@ rectangularPointyTopMap height width =
         allLines =
             List.concat <|
                 List.map widthRowLine heightLine
+
+        makeDictRecord : Hex -> ( Hash, Hex )
+        makeDictRecord hex =
+            ( hashHex hex, hex )
+    in
+    Dict.fromList <| List.map makeDictRecord allLines
+
+{-| Generate Map of rectangular shape given its height and width
+-}
+rectangularFlatTopMap : Int -> Int -> Map
+rectangularFlatTopMap height width =
+    let
+        widthLine =
+            List.range 0 width
+
+        heightLine =
+            List.range 0 height
+
+        createHex : Int -> Int -> Hex
+        createHex q r =
+            Hexagons.Hex.intFactory ( q, r )
+
+        offsetHeight : Int -> Int -> Int
+        offsetHeight q r =
+            r - (q // 2)
+
+        widthColumnLine : Int -> List Hex
+        widthColumnLine q =
+            List.map (createHex q) <|
+                List.map (offsetHeight q) heightLine
+
+        allLines : List Hex
+        allLines =
+            List.concat <|
+                List.map widthColumnLine widthLine
 
         makeDictRecord : Hex -> ( Hash, Hex )
         makeDictRecord hex =

--- a/tests/LayoutTest.elm
+++ b/tests/LayoutTest.elm
@@ -12,24 +12,36 @@ import Test exposing (..)
 layout : Test
 layout =
     let
-        testLayout =
+        testLayoutPointy =
             { orientation = Hexagons.Layout.orientationLayoutPointy
             , size = ( 10.0, 10.0 )
             , origin = ( 0.0, 0.0 )
             }
-
+        testLayoutFlat =
+            { orientation = Hexagons.Layout.orientationLayoutFlat
+            , size = ( 10.0, 10.0 )
+            , origin = ( 0.0, 0.0 )
+            }
         isEq arg1 arg2 =
             Expect.true "Expect that Hexes are equal" <|
                 eq arg1 arg2
     in
     describe "Test Hexagons.Layout module"
-        [ test "Turn Hex coordinates into a Point location on a Layout" <|
+        [ test "Turn Hex coordinates into a Point location on a pointy Layout" <|
             \_ ->
-                Hexagons.Layout.hexToPoint testLayout (IntCubeHex ( 2, 3, -5 ))
+                Hexagons.Layout.hexToPoint testLayoutPointy (IntCubeHex ( 2, 3, -5 ))
                     |> Expect.equal ( 60.62, 45.0 )
-        , test "Turn Point location on a Layout into a Hex coordinates" <|
+        , test "Turn Point location on a pointy Layout into a Hex coordinates" <|
             \_ ->
-                (Hexagons.Hex.toIntHex <| Hexagons.Layout.pointToHex testLayout ( 60.62, 45.0 ))
+                (Hexagons.Hex.toIntHex <| Hexagons.Layout.pointToHex testLayoutPointy ( 60.62, 45.0 ))
+                    |> isEq (IntCubeHex ( 2, 3, -5 ))
+        , test "Turn Hex coordinates into a Point location on a flat Layout" <|
+            \_ ->
+                Hexagons.Layout.hexToPoint testLayoutFlat (IntCubeHex ( 2, 3, -5 ))
+                    |> Expect.equal ( 30.0, 69.28 )
+        , test "Turn Point location on a flat Layout into a Hex coordinates" <|
+            \_ ->
+                (Hexagons.Hex.toIntHex <| Hexagons.Layout.pointToHex testLayoutFlat ( 30.0, 69.28 ))
                     |> isEq (IntCubeHex ( 2, 3, -5 ))
         , test "Turn offset cordinates to a Hex coordinates" <|
             \_ ->
@@ -39,10 +51,14 @@ layout =
             \_ ->
                 Hexagons.Layout.hexToOffset (IntCubeHex ( 2, 2, -4 ))
                     |> Expect.equal ( 3, 2 )
-        , test "Calculate polygon corner positions for a Hex location on a Layout" <|
+        , test "Calculate polygon corner positions for a Hex location on a pointy Layout" <|
             \_ ->
-                Hexagons.Layout.polygonCorners testLayout (IntCubeHex ( 2, 3, -5 ))
+                Hexagons.Layout.polygonCorners testLayoutPointy (IntCubeHex ( 2, 3, -5 ))
                     |> Expect.equal [ ( 69.28, 50 ), ( 60.62, 55 ), ( 51.96, 50 ), ( 51.96, 40 ), ( 60.62, 35 ), ( 69.28, 40 ) ]
+        , test "Calculate polygon corner positions for a Hex location on a flat Layout" <|
+            \_ ->
+                Hexagons.Layout.polygonCorners testLayoutFlat (IntCubeHex ( 2, 3, -5 ))
+                    |> Expect.equal [ ( 40, 69.28 ), ( 35, 77.94 ), ( 25, 77.94 ), ( 20, 69.28 ), ( 25, 60.62 ), ( 35, 60.62 ) ]
         , test "Draw a line between 2 Hexes returning a list of Hex connections" <|
             \_ ->
                 Hexagons.Layout.drawLine (IntCubeHex ( 2, 3, -5 )) (IntCubeHex ( 3, 3, -6 ))

--- a/tests/MapTest.elm
+++ b/tests/MapTest.elm
@@ -27,4 +27,20 @@ map =
                     |> Dict.diff (Hexagons.Map.rectangularPointyTopMap 2 2)
                     |> Dict.isEmpty
                     |> Expect.true "Expect that generated map is the same as sample"
+        , test "Generation of rectangular map with flat-top hexagons" <|
+            \_ ->
+                [ ( ( 0, 0, 0 ), IntCubeHex ( 0, 0, 0 ) )
+                , ( ( 0, 1, -1 ), IntCubeHex ( 0, 1, -1 ) )
+                , ( ( 0, 2, -2 ), IntCubeHex ( 0, 2, -2 ) )
+                , ( ( 1, 0, -1 ), IntCubeHex ( 1, 0, -1 ) )
+                , ( ( 1, 1, -2 ), IntCubeHex ( 1, 1, -2 ) )
+                , ( ( 1, 2, -3 ), IntCubeHex ( 1, 2, -3 ) )
+                , ( ( 2, -1, -1 ), IntCubeHex ( 2, -1, -1 ) )
+                , ( ( 2, 0, -2 ), IntCubeHex ( 2, 0, -2 ) )
+                , ( ( 2, 1, -3 ), IntCubeHex ( 2, 1, -3 ) )
+                ]
+                    |> Dict.fromList
+                    |> Dict.diff (Hexagons.Map.rectangularFlatTopMap 2 2)
+                    |> Dict.isEmpty
+                    |> Expect.true "Expect that generated map is the same as sample"
         ]


### PR DESCRIPTION
I have added two functions for creating hexagonal maps with flat-topped hexagons. The added functions are `orientationLayoutFlat` in Layout.elm and `rectangularFlatTopMap` in Map.elm.

I have also added tests for the corresponding files, so that everything that was tested with pointy topped hexagons is now also tested with flat-topped hexagons. 